### PR TITLE
Remove trailing / from gtest URL, link is broken

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -4,7 +4,7 @@ export CMAKE_LOCATION="http://www.cmake.org/files/v3.11/"
 export CMAKEVERSION_REQUIRED=cmake-3.11.1
 export CMAKEVERSION=cmake-3.11.1
 
-export GTEST_LOCATION="https://github.com/google/googletest/archive/"
+export GTEST_LOCATION="https://github.com/google/googletest/archive"
 export GTESTVERSION=release-1.7.0
 
 export GSL_LOCATION="http://ftpmirror.gnu.org/gsl/"


### PR DESCRIPTION
Trying to build FairSoft v17.10b currently fails on Ubuntu 18.04.

`This version is okay. Don't install cmake as external package.`
`*** Downloading gtest sources ***`
`  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current`
`                                 Dload  Upload   Total   Spent    Left  Speed`
`  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0`
`100    15  100    15    0     0      5      0  0:00:03  0:00:02  0:00:01    24`
`*** Unpacking release-1.7.0.tar.gz ..............`
`--E-- Cannot unpack package gtest`

The reason for this seems to be a broken gtest download URL:
`$ wget https://github.com/google/googletest/archive//release-1.7.0.tar.gz`
`--2018-08-19 09:39:58--  https://github.com/google/googletest/archive//release-1.7.0.tar.gz`
`Resolving github.com (github.com)... 192.30.253.112, 192.30.253.113`
`Connecting to github.com (github.com)|192.30.253.112|:443... connected.`
`HTTP request sent, awaiting response... 302 Found`
`Location: https://codeload.github.com/google/googletest/tar.gz//release-1.7.0 [following]`
`--2018-08-19 09:39:58--  https://codeload.github.com/google/googletest/tar.gz//release-1.7.0`
`Resolving codeload.github.com (codeload.github.com)... 192.30.253.121, 192.30.253.120`
`Connecting to codeload.github.com (codeload.github.com)|192.30.253.121|:443... connected.`
`HTTP request sent, awaiting response... 404 Not Found`
`2018-08-19 09:39:59 ERROR 404: Not Found.` 

This patch removes the trailing slash from `export GTEST_LOCATION="https://github.com/google/googletest/archive/"` which causes the download to succeed.

`This version is okay. Don't install cmake as external package.`
`*** Downloading gtest sources ***`
`  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current`
`                                 Dload  Upload   Total   Spent    Left  Speed`
`  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0`
`100  457k  100  457k    0     0   259k      0  0:00:01  0:00:01 --:--:--  620k`
`*** Unpacking release-1.7.0.tar.gz ..............`
`*** Compiling gtest ................ `